### PR TITLE
style: format code and update prompts

### DIFF
--- a/src/bilianalyzer/__main__.py
+++ b/src/bilianalyzer/__main__.py
@@ -14,10 +14,12 @@ from .fetch.comments import (
 from .analyze.comments import CommentAnalyzer, save_analysis
 from .utils import *
 
+
 @click.group()
 def main():
     """BiliAnalyzer: Fetch and Analyze Bilibili Comments"""
-    
+
+
 main.add_command(auth_commands.auth)
 main.add_command(fetch_commands.fetch)
 main.add_command(analyze_commands.analyze)

--- a/src/bilianalyzer/auth.py
+++ b/src/bilianalyzer/auth.py
@@ -75,6 +75,6 @@ def save_credential(credential: Credential) -> None:
         json.dump(cookies, f)
 
 
-def logout_operation() -> None:
+def remove_credential() -> None:
     if os.path.exists("credential.json"):
         os.remove("credential.json")

--- a/src/bilianalyzer/commands/analyze_commands.py
+++ b/src/bilianalyzer/commands/analyze_commands.py
@@ -4,13 +4,23 @@ from ..analyze.comments import CommentAnalyzer, Analysis
 from ..fetch.comments import load_video_info, load_replies
 import asyncio
 
+
 @click.argument("input", type=str)
-@click.option('-o', '--output', type=str, default='analysis_results.json', help='Output filepath for analysis results (default: analysis_results.json)')
-@click.command(help="Analyze comments from a file\n\n"
-               "POSITIONAL ARGUMENTS:\n\n"
-               "INPUT: Input file with comments to analyze")
+@click.option(
+    "-o",
+    "--output",
+    type=str,
+    default="analysis_results.json",
+    help="Output filepath for analysis results (default: analysis_results.json)",
+)
+@click.command(
+    help="Analyze comments from a file\n\n"
+    "POSITIONAL ARGUMENTS:\n\n"
+    "INPUT: Input file with comments to analyze"
+)
 def analyze(input, output):
     """Analyze comments from a file"""
+
     async def async_analyze():
         video_info = load_video_info(filepath="video_info.json")
         replies = load_replies(filepath=input)

--- a/src/bilianalyzer/commands/analyze_commands.py
+++ b/src/bilianalyzer/commands/analyze_commands.py
@@ -13,13 +13,9 @@ import asyncio
     default="analysis_results.json",
     help="Output filepath for analysis results (default: analysis_results.json)",
 )
-@click.command(
-    help="Analyze comments from a file\n\n"
-    "POSITIONAL ARGUMENTS:\n\n"
-    "INPUT: Input file with comments to analyze"
-)
+@click.command(help="Analyze comments from file INPUT")
 def analyze(input, output):
-    """Analyze comments from a file"""
+    """Analyze comments from a file INPUT"""
 
     async def async_analyze():
         video_info = load_video_info(filepath="video_info.json")

--- a/src/bilianalyzer/commands/auth_commands.py
+++ b/src/bilianalyzer/commands/auth_commands.py
@@ -1,5 +1,5 @@
 import click
-from ..auth import check, login_from_cookies, logout_operation
+from ..auth import check, login_from_cookies, remove_credential
 
 
 @click.group()
@@ -29,5 +29,5 @@ def login():
 @auth.command()
 def logout():
     """Logout BiliAnalyzer and Remove Stored Cookies"""
-    logout_operation()
+    remove_credential()
     click.echo("BiliAnalyzer Logged Out Successfully")

--- a/src/bilianalyzer/commands/auth_commands.py
+++ b/src/bilianalyzer/commands/auth_commands.py
@@ -6,27 +6,23 @@ from ..auth import check, login_from_cookies, logout_operation
 def auth():
     """Authenticate BiliAnalyzer with Bilibili Cookies"""
 
+
 @auth.command()
 def status():
     """Check Authentication Status of BiliAnalyzer"""
     click.echo(check())
 
+
 @auth.command()
 def login():
     """Login and Store Cookies for BiliAnalyzer"""
-    sessdata: str = click.prompt(
-                        "Please enter your sessdata cookie for bilibili: "
-                    )
-    bili_jct: str = click.prompt(
-                        "Please enter your bili_jct cookie for bilibili: "
-                    )
+    sessdata: str = click.prompt("Please enter your sessdata cookie for bilibili: ")
+    bili_jct: str = click.prompt("Please enter your bili_jct cookie for bilibili: ")
     try:
-        credential = login_from_cookies(
-                    sessdata=sessdata, bili_jct=bili_jct
-                        )
+        credential = login_from_cookies(sessdata=sessdata, bili_jct=bili_jct)
     except ValueError as error:
-            click.echo(f"Login Failed: {error}")
-            return                    
+        click.echo(f"Login Failed: {error}")
+        return
     click.echo("BiliAnalyzer Logged In Successfully")
 
 
@@ -35,4 +31,3 @@ def logout():
     """Logout BiliAnalyzer and Remove Stored Cookies"""
     logout_operation()
     click.echo("BiliAnalyzer Logged Out Successfully")
-

--- a/src/bilianalyzer/commands/fetch_commands.py
+++ b/src/bilianalyzer/commands/fetch_commands.py
@@ -25,11 +25,7 @@ from ..fetch.comments import Fetcher, save_replies, save_video_info
     is_flag=True,
     help="Skip authentication and fetch comments without credentials",
 )
-@click.command(
-    help="Fetch comments for a video with given BVID\n\n"
-    "POSITIONAL ARGUMENTS:\n\n"
-    "BVID: Bilibili video identifier (e.g. BV1xx411c7mz)"
-)
+@click.command(help="Fetch comments for a video with given BVID")
 def fetch(bvid, limit, output, no_auth):
     """Fetch comments for a video with given BVID"""
 

--- a/src/bilianalyzer/commands/fetch_commands.py
+++ b/src/bilianalyzer/commands/fetch_commands.py
@@ -4,18 +4,35 @@ from bilibili_api import Credential
 from ..auth import load_credential
 from ..fetch.comments import Fetcher, save_replies, save_video_info
 
-@click.argument('bvid',type=str)
+
+@click.argument("bvid", type=str)
 @click.option(
-    '-n', '--limit', type=int, default=10, help='Limit the maximum number of pages to fetch (default: 10)')
+    "-n",
+    "--limit",
+    type=int,
+    default=10,
+    help="Limit the maximum number of pages to fetch (default: 10)",
+)
 @click.option(
-    '-o', '--output', type=str, default='comments.json', help='Output filepath  for comments (default: comments.json)')
+    "-o",
+    "--output",
+    type=str,
+    default="comments.json",
+    help="Output filepath  for comments (default: comments.json)",
+)
 @click.option(
-    '--no-auth', is_flag=True, help='Skip authentication and fetch comments without credentials')
-@click.command(help="Fetch comments for a video with given BVID\n\n"
-                "POSITIONAL ARGUMENTS:\n\n"
-                "BVID: Bilibili video identifier (e.g. BV1xx411c7mz)")
+    "--no-auth",
+    is_flag=True,
+    help="Skip authentication and fetch comments without credentials",
+)
+@click.command(
+    help="Fetch comments for a video with given BVID\n\n"
+    "POSITIONAL ARGUMENTS:\n\n"
+    "BVID: Bilibili video identifier (e.g. BV1xx411c7mz)"
+)
 def fetch(bvid, limit, output, no_auth):
     """Fetch comments for a video with given BVID"""
+
     async def async_fetch():
         credential: Credential = Credential()
         if not no_auth:
@@ -31,4 +48,5 @@ def fetch(bvid, limit, output, no_auth):
 
         # TODO: replace hardcoded video_info filepath
         save_video_info(video_info, filepath="video_info.json")
+
     asyncio.run(async_fetch())


### PR DESCRIPTION
auto format code with black to keep better readability
modify subcommand prompts according to `click` docs
as positional arguments should be minimized and compulsory
their prompts should be included directly in the command prompt
instead of a seperate section of `POSITIONAL ARGUMENTS`

- **style: auto format code with black**
- **fix: modify subcommand prompts**
